### PR TITLE
[UPDATE] #BTS-160 : 구매한 에피소드 목록 조회 (최신순으로 + 주문번호)

### DIFF
--- a/src/main/java/com/readme/payments/payments/responseObject/ResponseGetPurchasedInfo.java
+++ b/src/main/java/com/readme/payments/payments/responseObject/ResponseGetPurchasedInfo.java
@@ -14,4 +14,6 @@ public class ResponseGetPurchasedInfo {
     String thumbnail;
     String episodeTitle;
     LocalDateTime purchasedDate;
+
+    Long purchasedId;
 }


### PR DESCRIPTION
- 구매내역을 최신순으로 정렬하고 주문번호도 보이게 했습니다